### PR TITLE
Rename include_top to require_flatten

### DIFF
--- a/keras_vggface/vggface.py
+++ b/keras_vggface/vggface.py
@@ -81,7 +81,7 @@ def VGGFace(include_top=True, weights='vggface',
                                       default_size=224,
                                       min_size=48,
                                       data_format=K.image_data_format(),
-                                      include_top=include_top)
+                                      require_flatten=include_top)
 
     if input_tensor is None:
         img_input = Input(shape=input_shape)


### PR DESCRIPTION
Due to keras rename switch  include_top to require_flatten in _obtain_input_shape