### PR TITLE
Make tensorflow be optional to allow using tensorflow-gpu

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,21 @@
 from setuptools import setup, find_packages
 exec(open('keras_vggface/version.py').read())
-setup(name='keras_vggface',
-      version=__version__,
-      description='VGGFace implementation with Keras framework',
-      url='https://github.com/rcmalli/keras-vggface',
-      author='Refik Can MALLI',
-      author_email = "mallir@itu.edu.tr",
-      license='MIT',
-      keywords = ['keras', 'vggface', 'deeplearning'],
-      packages=find_packages(exclude=["temp", "test", "data", "visualize"]),
-      zip_safe=False,
-      install_requires=['numpy>=1.9.1',
-                        'scipy>=0.14',
-                        'h5py',
-                        'pillow',
-                        'tensorflow',
-                        'keras',
-                        'six>=1.9.0',
-                        'pyyaml'])
+setup(
+    name='keras_vggface',
+    version=__version__,
+    description='VGGFace implementation with Keras framework',
+    url='https://github.com/rcmalli/keras-vggface',
+    author='Refik Can MALLI',
+    author_email="mallir@itu.edu.tr",
+    license='MIT',
+    keywords=['keras', 'vggface', 'deeplearning'],
+    packages=find_packages(exclude=["temp", "test", "data", "visualize"]),
+    zip_safe=False,
+    install_requires=[
+        'numpy>=1.9.1', 'scipy>=0.14', 'h5py', 'pillow', 'keras',
+        'six>=1.9.0', 'pyyaml'
+    ],
+    extras_require={
+        "tf": ["tensorflow"],
+        "tf_gpu": ["tensorflow-gpu"],
+    })


### PR DESCRIPTION
As `tensorflow` is listed as a dependency of this project, if `tensorflow-gpu` (the GPU / Nvidia version) is installed, it will be overwritten and not used. It makes this package incompatible with GPUs and only work in CPU.

The change is based on one of the possible workarounds suggested in a related TensorFlow issue: https://github.com/tensorflow/tensorflow/issues/7166

The change is only the section with:

```Python
 extras_require={
        "tf": ["tensorflow"],
        "tf_gpu": ["tensorflow-gpu"],
    })
```

The rest is just auto-formatting (`yapf`).