### PR TITLE
fix _obtain_input_shape namespace change

### DIFF
--- a/keras_vggface/models.py
+++ b/keras_vggface/models.py
@@ -12,7 +12,7 @@
 from keras.layers import Flatten, Dense, Input, GlobalAveragePooling2D, \
     GlobalMaxPooling2D, Activation, Conv2D, MaxPooling2D, BatchNormalization, \
     AveragePooling2D, Reshape, Permute, multiply
-from keras.applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import _obtain_input_shape
 from keras.utils import layer_utils
 from keras.utils.data_utils import get_file
 from keras import backend as K


### PR DESCRIPTION
fixes ImportError: cannot import name '_obtain_input_shape'

Change introduced in keras 2.2.2 where '_obtain_input_shape' is now in keras_application 