### PR TITLE
Fast fixes for compatibility with tensorflow 2.6

### DIFF
--- a/keras_vggface/models.py
+++ b/keras_vggface/models.py
@@ -9,18 +9,20 @@
 '''
 
 
-from keras.layers import Flatten, Dense, Input, GlobalAveragePooling2D, \
+from tensorflow.keras.layers import Flatten, Dense, Input, GlobalAveragePooling2D, \
     GlobalMaxPooling2D, Activation, Conv2D, MaxPooling2D, BatchNormalization, \
     AveragePooling2D, Reshape, Permute, multiply
+#from tensorflow.keras.applications.imagenet_utils import _obtain_input_shape
 from keras_applications.imagenet_utils import _obtain_input_shape
-from keras.utils import layer_utils
-from keras.utils.data_utils import get_file
-from keras import backend as K
+from tensorflow.python.keras.utils import layer_utils
+from tensorflow.python.keras.utils.data_utils import get_file
+from tensorflow.keras import backend as K
 from keras_vggface import utils
-from keras.engine.topology import get_source_inputs
+#from tensorflow.keras.engine.topology import get_source_inputs
+from tensorflow.keras.utils import get_source_inputs
 import warnings
-from keras.models import Model
-from keras import layers
+from tensorflow.keras.models import Model
+from tensorflow.keras import layers
 
 
 def VGG16(include_top=True, weights='vggface',

--- a/keras_vggface/utils.py
+++ b/keras_vggface/utils.py
@@ -8,8 +8,8 @@
 
 
 import numpy as np
-from keras import backend as K
-from keras.utils.data_utils import get_file
+from tensorflow.keras import backend as K
+from tensorflow.python.keras.utils.data_utils import get_file
 
 V1_LABELS_PATH = 'https://github.com/rcmalli/keras-vggface/releases/download/v2.0/rcmalli_vggface_labels_v1.npy'
 V2_LABELS_PATH = 'https://github.com/rcmalli/keras-vggface/releases/download/v2.0/rcmalli_vggface_labels_v2.npy'

--- a/keras_vggface/version.py
+++ b/keras_vggface/version.py
@@ -1,8 +1,8 @@
 __version__ = '0.6'
 
 def pretty_versions():
-    import keras
+    import tensorflow.keras
     import tensorflow as tf
-    k_version = keras.__version__
+    k_version = tensorflow.keras.__version__
     t_version = tf.__version__
     return "keras-vggface : {}, keras : {} , tensorflow : {} ".format(__version__,k_version,t_version)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='keras_vggface',
     version=__version__,
     description='VGGFace implementation with Keras framework',
-    url='https://github.com/rcmalli/keras-vggface',
+    url='https://github.com/DavidDoukhan/keras-vggface',
     author='Refik Can MALLI',
     author_email="mallir@itu.edu.tr",
     license='MIT',
@@ -12,10 +12,7 @@ setup(
     packages=find_packages(exclude=["tools", "training", "temp", "test", "data", "visualize","image",".venv",".github"]),
     zip_safe=False,
     install_requires=[
-        'numpy>=1.9.1', 'scipy>=0.14', 'h5py', 'pillow', 'keras',
-        'six>=1.9.0', 'pyyaml'
+        'numpy>=1.9.1', 'scipy>=0.14', 'h5py', 'pillow', 'tensorflow',
+        'six>=1.9.0', 'pyyaml', 'keras-applications'
     ],
-    extras_require={
-        "tf": ["tensorflow"],
-        "tf_gpu": ["tensorflow-gpu"],
-    })
+    )

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ from setuptools import setup, find_packages
 exec(open('keras_vggface/version.py').read())
 setup(
     name='keras_vggface',
-    version=__version__,
+    version=__version__ + '_vddk-0.1',
     description='VGGFace implementation with Keras framework',
     url='https://github.com/DavidDoukhan/keras-vggface',
-    author='Refik Can MALLI',
+    author='Refik Can MALLI & David Doukhan',
     author_email="mallir@itu.edu.tr",
     license='MIT',
     keywords=['keras', 'vggface', 'deeplearning'],

--- a/test.py
+++ b/test.py
@@ -1,15 +1,15 @@
 import numpy as np
 from keras_vggface import VGGFace
-from keras.preprocessing import image
+from tensorflow.keras.preprocessing import image
 from keras_vggface import utils
-import keras
+import tensorflow.keras
 import unittest
 
 
 class VGGFaceTests(unittest.TestCase):
 
     def testVGG16(self):
-        keras.backend.image_data_format()
+        tensorflow.keras.backend.image_data_format()
         model = VGGFace(model='vgg16')
         img = image.load_img('image/ajb.jpg', target_size=(224, 224))
         x = image.img_to_array(img)
@@ -23,7 +23,7 @@ class VGGFaceTests(unittest.TestCase):
         self.assertAlmostEqual(utils.decode_predictions(preds)[0][0][1], 0.9790116, places=3)
 
     def testRESNET50(self):
-        keras.backend.image_data_format()
+        tensorflow.keras.backend.image_data_format()
         model = VGGFace(model='resnet50')
         img = image.load_img('image/ajb.jpg', target_size=(224, 224))
         x = image.img_to_array(img)
@@ -37,7 +37,7 @@ class VGGFaceTests(unittest.TestCase):
         self.assertAlmostEqual(utils.decode_predictions(preds)[0][0][1], 0.91819614, places=3)
 
     def testSENET50(self):
-        keras.backend.image_data_format()
+        tensorflow.keras.backend.image_data_format()
         model = VGGFace(model='senet50')
         img = image.load_img('image/ajb.jpg', target_size=(224, 224))
         x = image.img_to_array(img)

--- a/tools/draw_networks.py
+++ b/tools/draw_networks.py
@@ -1,4 +1,4 @@
-from keras.utils import plot_model
+from tensorflow.keras.utils import plot_model
 from keras_vggface import VGGFace
 
 model = VGGFace(model='vgg16')


### PR DESCRIPTION
Dear @rcmalli ,

Please find bellow a small contribution to update keras-vggface and make it compliant with current tensorflow 2.6.
I use your package in one of my project which requires up-to-date version of tensorflow.

By the way, is there a way to cite your work when doing a publication ?

Kind regards,