### PR TITLE
Fix broken import in models.py

### DIFF
--- a/keras_vggface/models.py
+++ b/keras_vggface/models.py
@@ -17,7 +17,7 @@ from keras.utils import layer_utils
 from keras.utils.data_utils import get_file
 from keras import backend as K
 from keras_vggface import utils
-from keras.engine.topology import get_source_inputs
+from keras.utils.layer_utils import get_source_inputs
 import warnings
 from keras.models import Model
 from keras import layers


### PR DESCRIPTION
Resolves `ModuleNotFoundError: No module named 'keras.engine.topology'` and closes #73.